### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - 2.7
-  - 3.3
   - 3.4
   - 3.5
   - 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy-5.4.1
+  - pypy
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
 
@@ -24,4 +29,4 @@ install:
 cache: pip
 
 before_cache:
-    - rm -f $HOME/.cache/pip/log/debug.log
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ Changes
 - Fix the possibility of a rare crash in the C extension when deallocating items. See 
   https://github.com/zopefoundation/zope.i18nmessageid/issues/7
 
+- Add support for Python 3.7.
+
+
 4.1.0 (2017-05-02)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,13 @@
 Changes
 =======
 
-4.1.1 (unreleased)
+4.2.0 (unreleased)
 ------------------
 
 - Fix the possibility of a rare crash in the C extension when deallocating items. See 
   https://github.com/zopefoundation/zope.i18nmessageid/issues/7
+
+- Drop support for Python 3.3.
 
 - Add support for Python 3.7.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - python: 37
+    - python: 37-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
   matrix:
     - python: 27
     - python: 27-x64
-    - python: 33
-    - python: 33-x64
     - python: 34
     - python: 34-x64
     - python: 35

--- a/setup.py
+++ b/setup.py
@@ -37,26 +37,29 @@ codeoptimization_c = os.path.join('src', 'zope', 'i18nmessageid',
                                   "_zope_i18nmessageid_message.c")
 codeoptimization = Feature(
     "Optional code optimizations",
-    standard = True,
-    ext_modules = [Extension(
+    standard=True,
+    ext_modules=[Extension(
         "zope.i18nmessageid._zope_i18nmessageid_message",
         [os.path.normcase(codeoptimization_c)]
         )])
 
 extra = {
-    'extras_require': {'testing': ['nose', 'coverage'],
-                       'docs': ['Sphinx'],
-                      },
+    'extras_require': {
+        'testing': ['nose', 'coverage'],
+        'docs': ['Sphinx'],
+    },
 }
 
 if not is_pypy and not is_jython:
     # Jython cannot build the C optimizations, while on PyPy they are
     # anti-optimizations (the C extension compatibility layer is known-slow,
     # and defeats JIT opportunities).
-    extra['features'] = {'codeoptimization':codeoptimization}
+    extra['features'] = {'codeoptimization': codeoptimization}
+
 
 def read(*rnames):
     return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+
 
 class optional_build_ext(build_ext):
     """This class subclasses build_ext and allows
@@ -94,7 +97,9 @@ class optional_build_ext(build_ext):
         sys.stderr.write(str(e) + '\n')
         sys.stderr.write('*' * 80 + '\n')
 
-setup(name='zope.i18nmessageid',
+
+setup(
+    name='zope.i18nmessageid',
     version='4.1.1.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
@@ -118,6 +123,7 @@ setup(name='zope.i18nmessageid',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         'Natural Language :: English',
@@ -129,11 +135,11 @@ setup(name='zope.i18nmessageid',
     url='http://pypi.python.org/pypi/zope.i18nmessageid',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    namespace_packages=['zope',],
+    namespace_packages=['zope'],
     install_requires=['setuptools'],
     include_package_data=True,
     test_suite='zope.i18nmessageid.tests.test_suite',
     zip_safe=False,
-    cmdclass={'build_ext':optional_build_ext},
+    cmdclass={'build_ext': optional_build_ext},
     **extra
 )

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ class optional_build_ext(build_ext):
 
 setup(
     name='zope.i18nmessageid',
-    version='4.1.1.dev0',
+    version='4.2.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     description='Message Identifiers for internationalization',
@@ -119,7 +119,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,py36,pypy,pypy3,coverage,docs
+    py27,py33,py34,py35,py36,py37,pypy,pypy3,coverage,docs
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,py36,py37,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,py37,pypy,pypy3,coverage,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Also drop support for Python 3.3.

Also use unversioned 'pypy' on Travis CI, it should be recent enough nowadays
AFAIU.