### PR TITLE
Fix Appveyor build failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
   - pip install -e .
 
 build_script:
-  - pip install wheel
+  - pip install -U setuptools wheel
   - python -W ignore setup.py -q bdist_wheel
 
 test_script:


### PR DESCRIPTION
python setup.py bdist_wheel fails on Python 3.5 with
>  AttributeError: '_NamespacePath' object has no attribute 'sort'

somewhere in pkg_resources.  This was fixed in other projects by upgrading setuptools, so let's try that here too.