### PR TITLE
fix: ensure that 'Message.mapping' is immutable

### DIFF
--- a/src/zope/i18nmessageid/message.py
+++ b/src/zope/i18nmessageid/message.py
@@ -13,6 +13,8 @@
 ##############################################################################
 """I18n Messages and factories.
 """
+import types
+
 
 __docformat__ = "reStructuredText"
 _marker = object()
@@ -54,8 +56,10 @@ class Message(str):
             self.domain = domain
         if default is not _marker:
             self.default = default
-        if mapping is not _marker:
-            self.mapping = mapping
+        if mapping is None:
+            self.mapping = None
+        elif mapping is not _marker:
+            self.mapping = types.MappingProxyType(mapping)
         if msgid_plural is not _marker:
             self.msgid_plural = msgid_plural
         if default_plural is not _marker:
@@ -81,9 +85,17 @@ class Message(str):
             return str.__setattr__(self, key, value)
 
     def __getstate__(self):
+        # types.MappingProxyType is not picklable
+        mapping = None if self.mapping is None else dict(self.mapping)
         return (
-            str(self), self.domain, self.default, self.mapping,
-            self.msgid_plural, self.default_plural, self.number)
+            str(self),
+            self.domain,
+            self.default,
+            mapping,
+            self.msgid_plural,
+            self.default_plural,
+            self.number,
+        )
 
     def __reduce__(self):
         return self.__class__, self.__getstate__()

--- a/src/zope/i18nmessageid/tests.py
+++ b/src/zope/i18nmessageid/tests.py
@@ -53,8 +53,19 @@ class PyMessageTests(unittest.TestCase):
         self.assertEqual(message.msgid_plural, 'testings')
         self.assertEqual(message.default_plural, 'defaults')
         self.assertEqual(message.number, 2)
+
+        with self.assertRaises(TypeError):
+            message.mapping['key'] = 'new value'
+
         if self._TEST_READONLY:
             self.assertTrue(message._readonly)
+
+    def test_mapping_is_readonly(self):
+        mapping = {'key': 'value'}
+        message = self._makeOne('testing', 'domain', mapping=mapping)
+
+        with self.assertRaises(TypeError):
+            message.mapping['key'] = 'new value'
 
     def test_values_without_defaults(self):
         mapping = {'key': 'value'}
@@ -205,6 +216,16 @@ class PyMessageTests(unittest.TestCase):
         message = self._makeOne('testing')
         with self.assertRaises((TypeError, AttributeError)):
             message.unknown = 'unknown'
+
+    def test___reduce___wo_values(self):
+        message = self._makeOne('testing')
+        klass, state = message.__reduce__()
+        self.assertTrue(klass is self._getTargetClass())
+        self.assertTrue(message.mapping is None)
+        self.assertEqual(
+            state,
+            ('testing', None, None, None, None, None, None)
+        )
 
     def test___reduce__(self):
         mapping = {'key': 'value'}


### PR DESCRIPTION
Closes #1.

Note that this branch includes the changes from PR #48, in order to have CI passing (otherwise the `pypy3` build would fail).

I ~~will rebase~~ have rebased this PR after #48 ~~merges~~ merged.