### PR TITLE
Multi-phase module initialization

### DIFF
--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -16,7 +16,7 @@
 #include "structmember.h"
 
 /*
- *  Don't use multi-phase module init or heap types for Python < 3.9.
+ *  Don't use heap-allocated types for Python < 3.9.
  */
 #if PY_VERSION_HEX < 0x03090000
 #define USE_STATIC_TYPES 1

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -377,22 +377,24 @@ _zim_state_clear(PyObject* module)
 static int
 _zim_module_exec(PyObject* module)
 {
+    _zim_module_state* rec = _zim_state_init(module);
+
     /* Initialize / add types: */
 
 #if USE_STATIC_TYPES
-    _zim_state_init(module); /* no dynamic types, but ensure NULL */
 
     MessageType.tp_base = &PyUnicode_Type;
 
     if (PyType_Ready(&MessageType) < 0) {
         return -1;
     }
+    Py_INCREF(&MessageType);
+    rec->message_type = &MessageType;
 
     if (PyModule_AddObject(module, "Message", (PyObject*)&MessageType) < 0) {
         return -1;
     }
 #else
-    _zim_module_state* rec = _zim_state_init(module);
     PyObject* message_bases;  /* Python 3.9 insists on a tuple */
     PyObject* message_type;
 

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -89,7 +89,7 @@ Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
     PyObject *new_args;
     PyObject *new_str;
-    Message  *self;
+    Message  *new_msg;
     Message  *other;
 
     if (!PyArg_ParseTupleAndKeywords(
@@ -120,62 +120,62 @@ Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
         return NULL;
     }
 
-    self = (Message*)new_str;
+    new_msg = (Message*)new_str;
 
     if (PyObject_TypeCheck(value, &MessageType)) {
         /* value is a Message so we copy it and use it as base */
         other = (Message*)value;
-        self->domain = other->domain;
-        self->default_ = other->default_;
-        self->mapping = other->mapping;
-        self->value_plural = other->value_plural;
-        self->default_plural = other->default_plural;
-        self->number = other->number;
+        new_msg->domain = other->domain;
+        new_msg->default_ = other->default_;
+        new_msg->mapping = other->mapping;
+        new_msg->value_plural = other->value_plural;
+        new_msg->default_plural = other->default_plural;
+        new_msg->number = other->number;
     } else {
-        self->domain = NULL;
-        self->default_ = NULL;
-        self->mapping = NULL;
-        self->value_plural = NULL;
-        self->default_plural = NULL;
-        self->number = NULL;
+        new_msg->domain = NULL;
+        new_msg->default_ = NULL;
+        new_msg->mapping = NULL;
+        new_msg->value_plural = NULL;
+        new_msg->default_plural = NULL;
+        new_msg->number = NULL;
     }
 
     if (domain != NULL) {
-        self->domain = domain;
+        new_msg->domain = domain;
     }
 
     if (default_ != NULL) {
-        self->default_ = default_;
+        new_msg->default_ = default_;
     }
 
     if (mapping == Py_None) {
-        self->mapping = Py_None;
+        new_msg->mapping = Py_None;
         Py_INCREF(Py_None);
     } else if (mapping != NULL) {
         /* Ensure that our mapping is immutable */
-        self->mapping = PyDictProxy_New(mapping);
+        new_msg->mapping = PyDictProxy_New(mapping);
     } else {}
 
     if (value_plural != NULL) {
-        self->value_plural = value_plural;
+        new_msg->value_plural = value_plural;
     }
 
     if (default_plural != NULL) {
-        self->default_plural = default_plural;
+        new_msg->default_plural = default_plural;
     }
 
     if (number != NULL) {
-        self->number = number;
+        new_msg->number = number;
     }
 
-    /* Don't:  Py_XINCREF(self->mapping); we handed it above */
-    Py_XINCREF(self->default_);
-    Py_XINCREF(self->domain);
-    Py_XINCREF(self->value_plural);
-    Py_XINCREF(self->default_plural);
-    Py_XINCREF(self->number);
+    /* Don't:  Py_XINCREF(new_msg->mapping); we handed it above */
+    Py_XINCREF(new_msg->default_);
+    Py_XINCREF(new_msg->domain);
+    Py_XINCREF(new_msg->value_plural);
+    Py_XINCREF(new_msg->default_plural);
+    Py_XINCREF(new_msg->number);
 
-    return (PyObject*)self;
+    return (PyObject*)new_msg;
 }
 
 /*

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -273,27 +273,17 @@ static PyTypeObject MessageType = {
     .tp_members     = Message_members,
 };
 
-/* List of methods defined in the module */
-static struct PyMethodDef _zope_i18nmessageid_message_methods[] = {
-    { NULL, (PyCFunction)NULL, 0, NULL }, /* sentinel */
-};
+/*
+ *  Module initialization structures
+ */
 
-static char _zope_i18nmessageid_message_module_name[] =
-  "_zope_i18nmessageid_message";
-
-static char _zope_i18nmessageid_message_module_documentation[] =
-  "I18n Messages";
+static char _zim__name__[]  = "_zope_i18nmessageid_message";
+static char _zim__doc__[]   = "I18n Messages";
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    _zope_i18nmessageid_message_module_name,          /* m_name */
-    _zope_i18nmessageid_message_module_documentation, /* m_doc */
-    -1,                                               /* m_size */
-    _zope_i18nmessageid_message_methods,              /* m_methods */
-    NULL,                                             /* m_reload */
-    NULL,                                             /* m_traverse */
-    NULL,                                             /* m_clear */
-    NULL,                                             /* m_free */
+    .m_name=_zim__name__,
+    .m_doc=_zim__doc__,
 };
 
 static PyObject*

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -38,8 +38,9 @@ typedef struct
  */
 
 static int
-Message_traverse(Message* self, visitproc visit, void* arg)
+Message_traverse(PyObject* pyobj_self, visitproc visit, void* arg)
 {
+    Message* self = (Message*)pyobj_self;
     Py_VISIT(self->domain);
     Py_VISIT(self->default_);
     Py_VISIT(self->mapping);
@@ -50,8 +51,9 @@ Message_traverse(Message* self, visitproc visit, void* arg)
 }
 
 static int
-Message_clear(Message* self)
+Message_clear(PyObject* pyobj_self)
 {
+    Message* self = (Message*)pyobj_self;
     Py_CLEAR(self->domain);
     Py_CLEAR(self->default_);
     Py_CLEAR(self->mapping);
@@ -62,9 +64,9 @@ Message_clear(Message* self)
 }
 
 static void
-Message_dealloc(Message* self)
+Message_dealloc(PyObject* self)
 {
-    PyObject_GC_UnTrack((PyObject*)self);
+    PyObject_GC_UnTrack(self);
     Message_clear(self);
     PyUnicode_Type.tp_dealloc((PyObject*)self);
 }

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -259,51 +259,19 @@ static char MessageType__doc__[] =
 
 static PyTypeObject MessageType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    /* tp_name           */ "zope.i18nmessageid.message."
-                            "Message",
-    /* tp_basicsize      */ sizeof(Message),
-    /* tp_itemsize       */ 0,
-    /* tp_dealloc        */ (destructor)&Message_dealloc,
-    /* tp_print          */ (printfunc)0,
-    /* tp_getattr        */ (getattrfunc)0,
-    /* tp_setattr        */ (setattrfunc)0,
-    /* tp_compare        */ 0,
-    /* tp_repr           */ (reprfunc)0,
-    /* tp_as_number      */ 0,
-    /* tp_as_sequence    */ 0,
-    /* tp_as_mapping     */ 0,
-    /* tp_hash           */ (hashfunc)0,
-    /* tp_call           */ (ternaryfunc)0,
-    /* tp_str            */ (reprfunc)0,
-    /* tp_getattro       */ (getattrofunc)0,
-    /* tp_setattro       */ (setattrofunc)0,
-    /* tp_as_buffer      */ 0,
-    /* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
-      Py_TPFLAGS_HAVE_GC,
-    /* tp_doc            */ MessageType__doc__,
-    /* tp_traverse       */ (traverseproc)Message_traverse,
-    /* tp_clear          */ (inquiry)Message_clear,
-    /* tp_richcompare    */ (richcmpfunc)0,
-    /* tp_weaklistoffset */ (long)0,
-    /* tp_iter           */ (getiterfunc)0,
-    /* tp_iternext       */ (iternextfunc)0,
-    /* tp_methods        */ Message_methods,
-    /* tp_members        */ Message_members,
-    /* tp_getset         */ 0,
-    /* tp_base           */ 0,
-    /* tp_dict           */ 0, /* internal use */
-    /* tp_descr_get      */ (descrgetfunc)0,
-    /* tp_descr_set      */ (descrsetfunc)0,
-    /* tp_dictoffset     */ 0,
-    /* tp_init           */ (initproc)0,
-    /* tp_alloc          */ (allocfunc)0,
-    /* tp_new            */ (newfunc)Message_new,
-    /* tp_free           */ 0,          /* Low-level free-mem routine */
-    /* tp_is_gc          */ (inquiry)0, /* For PyObject_IS_GC */
+    .tp_name        = "zope.i18nmessageid.message.Message",
+    .tp_doc         = MessageType__doc__,
+    .tp_basicsize   = sizeof(Message),
+    .tp_flags       = Py_TPFLAGS_DEFAULT |
+                      Py_TPFLAGS_BASETYPE |
+                      Py_TPFLAGS_HAVE_GC,
+    .tp_new         = Message_new,
+    .tp_traverse    = Message_traverse,
+    .tp_clear       = Message_clear,
+    .tp_dealloc     = Message_dealloc,
+    .tp_methods     = Message_methods,
+    .tp_members     = Message_members,
 };
-
-/* End of code for Message objects */
-/* -------------------------------------------------------- */
 
 /* List of methods defined in the module */
 static struct PyMethodDef _zope_i18nmessageid_message_methods[] = {

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -176,6 +176,15 @@ Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     return (PyObject*)self;
 }
 
+/*
+ * Message type methods
+ */
+
+static char Message_reduce__doc__[] = (
+    "Reduce messages to a serializable form\n\n"
+    "Notably, for use in pickling."
+);
+
 static PyObject*
 Message_reduce(Message* self)
 {
@@ -217,8 +226,9 @@ Message_reduce(Message* self)
     return result;
 }
 
-/* Code to access structure members by accessing attributes */
-
+/*
+ *  Message type declaration structures
+ */
 
 static PyMemberDef Message_members[] = {
     { "domain", T_OBJECT, offsetof(Message, domain), READONLY },
@@ -232,9 +242,7 @@ static PyMemberDef Message_members[] = {
 
 static PyMethodDef Message_methods[] = {
     { "__reduce__",
-      (PyCFunction)Message_reduce,
-      METH_NOARGS,
-      "Reduce messages to a serializable form." },
+        (PyCFunction)Message_reduce, METH_NOARGS, Message_reduce__doc__ },
     { NULL } /* Sentinel */
 };
 

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -14,108 +14,118 @@
 
 #include "Python.h"
 
-
-typedef struct {
-  PyUnicodeObject base;
-  PyObject *domain;
-  PyObject *default_;
-  PyObject *mapping;
-  PyObject *value_plural;
-  PyObject *default_plural;
-  PyObject *number;
+typedef struct
+{
+    PyUnicodeObject base;
+    PyObject* domain;
+    PyObject* default_;
+    PyObject* mapping;
+    PyObject* value_plural;
+    PyObject* default_plural;
+    PyObject* number;
 } Message;
 
 static PyTypeObject MessageType;
 
-static PyObject *
-Message_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject*
+Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 {
-  static char *kwlist[] = {"value", "domain", "default", "mapping",
-                           "msgid_plural", "default_plural", "number", NULL};
-  PyObject *value, *domain=NULL, *default_=NULL, *mapping=NULL, *s;
-  PyObject *value_plural=NULL, *default_plural=NULL, *number=NULL;
-  Message *self;
+    static char* kwlist[] = { "value",        "domain",
+                              "default",      "mapping",
+                              "msgid_plural", "default_plural",
+                              "number",       NULL };
+    PyObject *value, *domain = NULL, *default_ = NULL, *mapping = NULL, *s;
+    PyObject *value_plural = NULL, *default_plural = NULL, *number = NULL;
+    Message* self;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|OOOOOO", kwlist,
-                                   &value, &domain, &default_, &mapping,
-                                   &value_plural, &default_plural, &number))
-    return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args,
+                                     kwds,
+                                     "O|OOOOOO",
+                                     kwlist,
+                                     &value,
+                                     &domain,
+                                     &default_,
+                                     &mapping,
+                                     &value_plural,
+                                     &default_plural,
+                                     &number))
+        return NULL;
 
-  if (number != NULL && Py_None != number) {
-    if (!(PyLong_Check(number) || PyFloat_Check(number))) {
-      PyErr_SetString(PyExc_TypeError,
-                      "`number` should be an integer or a float");
-      return NULL;
+    if (number != NULL && Py_None != number) {
+        if (!(PyLong_Check(number) || PyFloat_Check(number))) {
+            PyErr_SetString(PyExc_TypeError,
+                            "`number` should be an integer or a float");
+            return NULL;
+        }
     }
-  }
 
-  args = Py_BuildValue("(O)", value);
-  if (args == NULL)
-    return NULL;
+    args = Py_BuildValue("(O)", value);
+    if (args == NULL)
+        return NULL;
 
-  s = PyUnicode_Type.tp_new(type, args, NULL);
-  Py_DECREF(args);
-  if (s == NULL)
-    return NULL;
+    s = PyUnicode_Type.tp_new(type, args, NULL);
+    Py_DECREF(args);
+    if (s == NULL)
+        return NULL;
 
-  if (!PyObject_TypeCheck(s, &MessageType)) {
-    PyErr_SetString(PyExc_TypeError, "unicode.__new__ didn't return a Message");
-    Py_DECREF(s);
-    return NULL;
-  }
+    if (!PyObject_TypeCheck(s, &MessageType)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "unicode.__new__ didn't return a Message");
+        Py_DECREF(s);
+        return NULL;
+    }
 
-  self = (Message*)s;
+    self = (Message*)s;
 
-  if (PyObject_TypeCheck(value, &MessageType)) {
-    /* value is a Message so we copy it and use it as base */
-    self->domain = ((Message *)value)->domain;
-    self->default_ = ((Message *)value)->default_;
-    self->mapping = ((Message *)value)->mapping;
-    self->value_plural = ((Message *)value)->value_plural;
-    self->default_plural = ((Message *)value)->default_plural;
-    self->number = ((Message *)value)->number;
-  }
-  else {
-    self->domain = NULL;
-    self->default_ = NULL;
-    self->mapping = NULL;
-    self->value_plural = NULL;
-    self->default_plural = NULL;
-    self->number = NULL;
-  }
+    if (PyObject_TypeCheck(value, &MessageType)) {
+        /* value is a Message so we copy it and use it as base */
+        self->domain = ((Message*)value)->domain;
+        self->default_ = ((Message*)value)->default_;
+        self->mapping = ((Message*)value)->mapping;
+        self->value_plural = ((Message*)value)->value_plural;
+        self->default_plural = ((Message*)value)->default_plural;
+        self->number = ((Message*)value)->number;
+    } else {
+        self->domain = NULL;
+        self->default_ = NULL;
+        self->mapping = NULL;
+        self->value_plural = NULL;
+        self->default_plural = NULL;
+        self->number = NULL;
+    }
 
-  if (domain != NULL)
-    self->domain = domain;
+    if (domain != NULL)
+        self->domain = domain;
 
-  if (default_ != NULL)
-    self->default_ = default_;
+    if (default_ != NULL)
+        self->default_ = default_;
 
-  if (mapping == Py_None) {
-    self->mapping = Py_None;
-    Py_INCREF(Py_None);
-  } else if (mapping != NULL) {
-    self->mapping = PyDictProxy_New(mapping);
-  } else {
-  }
+    if (mapping == Py_None) {
+        self->mapping = Py_None;
+        Py_INCREF(Py_None);
+    } else if (mapping != NULL) {
+        self->mapping = PyDictProxy_New(mapping);
+    } else {
+    }
 
-  if (value_plural != NULL)
-    self->value_plural = value_plural;
+    if (value_plural != NULL)
+        self->value_plural = value_plural;
 
-  if (default_plural != NULL)
-    self->default_plural = default_plural;
+    if (default_plural != NULL)
+        self->default_plural = default_plural;
 
-  if (number != NULL) {
-    self->number = number;
-  }
+    if (number != NULL) {
+        self->number = number;
+    }
 
-  Py_XINCREF(self->mapping);
-  Py_XINCREF(self->default_);
-  Py_XINCREF(self->domain);
-  Py_XINCREF(self->value_plural);
-  Py_XINCREF(self->default_plural);
-  Py_XINCREF(self->number);
+    Py_XINCREF(self->mapping);
+    Py_XINCREF(self->default_);
+    Py_XINCREF(self->domain);
+    Py_XINCREF(self->value_plural);
+    Py_XINCREF(self->default_plural);
+    Py_XINCREF(self->number);
 
-  return (PyObject *)self;
+    return (PyObject*)self;
 }
 
 /* Code to access structure members by accessing attributes */
@@ -123,99 +133,101 @@ Message_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 #include "structmember.h"
 
 static PyMemberDef Message_members[] = {
-  { "domain", T_OBJECT, offsetof(Message, domain), READONLY },
-  { "default", T_OBJECT, offsetof(Message, default_), READONLY },
-  { "mapping", T_OBJECT, offsetof(Message, mapping), READONLY },
-  { "msgid_plural", T_OBJECT, offsetof(Message, value_plural), READONLY },
-  { "default_plural", T_OBJECT, offsetof(Message, default_plural), READONLY },
-  { "number", T_OBJECT, offsetof(Message, number), READONLY },
-  {NULL}    /* Sentinel */
+    { "domain", T_OBJECT, offsetof(Message, domain), READONLY },
+    { "default", T_OBJECT, offsetof(Message, default_), READONLY },
+    { "mapping", T_OBJECT, offsetof(Message, mapping), READONLY },
+    { "msgid_plural", T_OBJECT, offsetof(Message, value_plural), READONLY },
+    { "default_plural", T_OBJECT, offsetof(Message, default_plural), READONLY },
+    { "number", T_OBJECT, offsetof(Message, number), READONLY },
+    { NULL } /* Sentinel */
 };
 
 static int
-Message_traverse(Message *self, visitproc visit, void *arg)
+Message_traverse(Message* self, visitproc visit, void* arg)
 {
-  Py_VISIT(self->domain);
-  Py_VISIT(self->default_);
-  Py_VISIT(self->mapping);
-  Py_VISIT(self->value_plural);
-  Py_VISIT(self->default_plural);
-  Py_VISIT(self->number);
-  return 0;
+    Py_VISIT(self->domain);
+    Py_VISIT(self->default_);
+    Py_VISIT(self->mapping);
+    Py_VISIT(self->value_plural);
+    Py_VISIT(self->default_plural);
+    Py_VISIT(self->number);
+    return 0;
 }
 
 static int
-Message_clear(Message *self)
+Message_clear(Message* self)
 {
-  Py_CLEAR(self->domain);
-  Py_CLEAR(self->default_);
-  Py_CLEAR(self->mapping);
-  Py_CLEAR(self->value_plural);
-  Py_CLEAR(self->default_plural);
-  Py_CLEAR(self->number);
-  return 0;
+    Py_CLEAR(self->domain);
+    Py_CLEAR(self->default_);
+    Py_CLEAR(self->mapping);
+    Py_CLEAR(self->value_plural);
+    Py_CLEAR(self->default_plural);
+    Py_CLEAR(self->number);
+    return 0;
 }
 
 static void
-Message_dealloc(Message *self)
+Message_dealloc(Message* self)
 {
-  PyObject_GC_UnTrack((PyObject *)self);
-  Message_clear(self);
-  PyUnicode_Type.tp_dealloc((PyObject*)self);
+    PyObject_GC_UnTrack((PyObject*)self);
+    Message_clear(self);
+    PyUnicode_Type.tp_dealloc((PyObject*)self);
 }
 
-static PyObject *
-Message_reduce(Message *self)
+static PyObject*
+Message_reduce(Message* self)
 {
-  PyObject *value, *mapping, *result;
-  value = PyObject_CallFunctionObjArgs((PyObject *)&PyUnicode_Type, self, NULL);
-  if (value == NULL)
-    return NULL;
-  if (self->mapping == NULL) {
-    mapping = Py_None;
-  }
-  else if (self->mapping == Py_None) {
-    mapping = Py_None;
-  } else {
-    mapping = PyObject_CallFunctionObjArgs(
-        (PyObject *)&PyDict_Type, self->mapping, NULL);
-    if (mapping == NULL) {
+    PyObject *value, *mapping, *result;
+    value =
+      PyObject_CallFunctionObjArgs((PyObject*)&PyUnicode_Type, self, NULL);
+    if (value == NULL)
         return NULL;
+    if (self->mapping == NULL) {
+        mapping = Py_None;
+    } else if (self->mapping == Py_None) {
+        mapping = Py_None;
+    } else {
+        mapping = PyObject_CallFunctionObjArgs(
+          (PyObject*)&PyDict_Type, self->mapping, NULL);
+        if (mapping == NULL) {
+            return NULL;
+        }
     }
-  }
-  result = Py_BuildValue("(O(OOOOOOO))", Py_TYPE(&(self->base)),
-             value,
-             self->domain ? self->domain : Py_None,
-             self->default_ ? self->default_ : Py_None,
-             mapping,
-             self->value_plural ? self->value_plural : Py_None,
-             self->default_plural ? self->default_plural : Py_None,
-             self->number ? self->number : Py_None);
-  Py_DECREF(value);
-  return result;
+    result =
+      Py_BuildValue("(O(OOOOOOO))",
+                    Py_TYPE(&(self->base)),
+                    value,
+                    self->domain ? self->domain : Py_None,
+                    self->default_ ? self->default_ : Py_None,
+                    mapping,
+                    self->value_plural ? self->value_plural : Py_None,
+                    self->default_plural ? self->default_plural : Py_None,
+                    self->number ? self->number : Py_None);
+    Py_DECREF(value);
+    return result;
 }
 
 static PyMethodDef Message_methods[] = {
-  {"__reduce__", (PyCFunction)Message_reduce, METH_NOARGS,
-   "Reduce messages to a serializable form."},
-  {NULL}  /* Sentinel */
+    { "__reduce__",
+      (PyCFunction)Message_reduce,
+      METH_NOARGS,
+      "Reduce messages to a serializable form." },
+    { NULL } /* Sentinel */
 };
 
-
 static char MessageType__doc__[] =
-"Message\n"
-"\n"
-"This is a string used as a message.  It has a domain attribute that is\n"
-"its source domain, and a default attribute that is its default text to\n"
-"display when there is no translation.  domain may be None meaning there is\n"
-"no translation domain.  default may also be None, in which case the\n"
-"message id itself implicitly serves as the default text.\n";
+  "Message\n"
+  "\n"
+  "This is a string used as a message.  It has a domain attribute that is\n"
+  "its source domain, and a default attribute that is its default text to\n"
+  "display when there is no translation.  domain may be None meaning there is\n"
+  "no translation domain.  default may also be None, in which case the\n"
+  "message id itself implicitly serves as the default text.\n";
 
-static PyTypeObject
-MessageType = {
+static PyTypeObject MessageType = {
     PyVarObject_HEAD_INIT(NULL, 0)
     /* tp_name           */ "zope.i18nmessageid.message."
-                                "Message",
+                            "Message",
     /* tp_basicsize      */ sizeof(Message),
     /* tp_itemsize       */ 0,
     /* tp_dealloc        */ (destructor)&Message_dealloc,
@@ -233,9 +245,8 @@ MessageType = {
     /* tp_getattro       */ (getattrofunc)0,
     /* tp_setattro       */ (setattrofunc)0,
     /* tp_as_buffer      */ 0,
-    /* tp_flags          */ Py_TPFLAGS_DEFAULT
-                            | Py_TPFLAGS_BASETYPE
-                            | Py_TPFLAGS_HAVE_GC,
+    /* tp_flags          */ Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE |
+      Py_TPFLAGS_HAVE_GC,
     /* tp_doc            */ MessageType__doc__,
     /* tp_traverse       */ (traverseproc)Message_traverse,
     /* tp_clear          */ (inquiry)Message_clear,
@@ -254,61 +265,59 @@ MessageType = {
     /* tp_init           */ (initproc)0,
     /* tp_alloc          */ (allocfunc)0,
     /* tp_new            */ (newfunc)Message_new,
-    /* tp_free           */ 0, /* Low-level free-mem routine */
+    /* tp_free           */ 0,          /* Low-level free-mem routine */
     /* tp_is_gc          */ (inquiry)0, /* For PyObject_IS_GC */
 };
 
 /* End of code for Message objects */
 /* -------------------------------------------------------- */
 
-
 /* List of methods defined in the module */
 static struct PyMethodDef _zope_i18nmessageid_message_methods[] = {
-  {NULL, (PyCFunction)NULL, 0, NULL},         /* sentinel */
+    { NULL, (PyCFunction)NULL, 0, NULL }, /* sentinel */
 };
 
 static char _zope_i18nmessageid_message_module_name[] =
-"_zope_i18nmessageid_message";
+  "_zope_i18nmessageid_message";
 
 static char _zope_i18nmessageid_message_module_documentation[] =
-"I18n Messages";
+  "I18n Messages";
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    _zope_i18nmessageid_message_module_name,/* m_name */
-    _zope_i18nmessageid_message_module_documentation,/* m_doc */
-    -1,/* m_size */
-    _zope_i18nmessageid_message_methods,/* m_methods */
-    NULL,/* m_reload */
-    NULL,/* m_traverse */
-    NULL,/* m_clear */
-    NULL,/* m_free */
+    _zope_i18nmessageid_message_module_name,          /* m_name */
+    _zope_i18nmessageid_message_module_documentation, /* m_doc */
+    -1,                                               /* m_size */
+    _zope_i18nmessageid_message_methods,              /* m_methods */
+    NULL,                                             /* m_reload */
+    NULL,                                             /* m_traverse */
+    NULL,                                             /* m_clear */
+    NULL,                                             /* m_free */
 };
-
 
 static PyObject*
 init(void)
 {
-  PyObject *m;
-  /* Initialize types: */
-  MessageType.tp_base = &PyUnicode_Type;
-  if (PyType_Ready(&MessageType) < 0) {
-    return NULL;
-  }
+    PyObject* m;
+    /* Initialize types: */
+    MessageType.tp_base = &PyUnicode_Type;
+    if (PyType_Ready(&MessageType) < 0) {
+        return NULL;
+    }
 
-  /* Create the module and add the functions */
-  m = PyModule_Create(&moduledef);
+    /* Create the module and add the functions */
+    m = PyModule_Create(&moduledef);
 
-  if (m == NULL) {
-    return NULL;
-  }
+    if (m == NULL) {
+        return NULL;
+    }
 
-  /* Add types: */
-  if (PyModule_AddObject(m, "Message", (PyObject *)&MessageType) < 0) {
-    return NULL;
-  }
+    /* Add types: */
+    if (PyModule_AddObject(m, "Message", (PyObject*)&MessageType) < 0) {
+        return NULL;
+    }
 
-  return m;
+    return m;
 }
 
 PyMODINIT_FUNC

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -15,8 +15,7 @@
 #include "Python.h"
 #include "structmember.h"
 
-/* Forward reference for type checking. */
-static PyTypeObject MessageType;
+static int is_message(PyObject* obj);  /* forward ref */
 
 /*
  *  Message type subclasses str
@@ -113,7 +112,7 @@ Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
     Py_DECREF(new_args);
     if (new_str == NULL) { return NULL; }
 
-    if (!PyObject_TypeCheck(new_str, &MessageType)) {
+    if (!is_message(new_str)) {
         PyErr_SetString(PyExc_TypeError,
                         "unicode.__new__ didn't return a Message");
         Py_DECREF(new_str);
@@ -122,7 +121,7 @@ Message_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
 
     new_msg = (Message*)new_str;
 
-    if (PyObject_TypeCheck(value, &MessageType)) {
+    if (is_message(value)) {
         /* value is a Message so we copy it and use it as base */
         other = (Message*)value;
         new_msg->domain = other->domain;
@@ -272,6 +271,14 @@ static PyTypeObject MessageType = {
     .tp_methods     = Message_methods,
     .tp_members     = Message_members,
 };
+
+/*
+ * Utility: returns True if 'obj' is an instance of 'MessageType'.
+ */
+static int is_message(PyObject* obj)
+{
+    return PyObject_TypeCheck(obj, &MessageType);
+}
 
 /*
  *  Module initialization structures

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -15,12 +15,6 @@
 #include "Python.h"
 
 
-#if PY_MAJOR_VERSION >= 3
-  #define MOD_ERROR_VAL NULL
-#else
-  #define MOD_ERROR_VAL
-#endif
-
 typedef struct {
   PyUnicodeObject base;
   PyObject *domain;
@@ -48,11 +42,7 @@ Message_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return NULL;
 
   if (number != NULL && Py_None != number) {
-#if PY_MAJOR_VERSION >= 3
     if (!(PyLong_Check(number) || PyFloat_Check(number))) {
-#else
-    if (!(PyLong_Check(number) || PyInt_Check(number) || PyFloat_Check(number))) {
-#endif
       PyErr_SetString(PyExc_TypeError,
                       "`number` should be an integer or a float");
       return NULL;
@@ -283,8 +273,7 @@ static char _zope_i18nmessageid_message_module_name[] =
 static char _zope_i18nmessageid_message_module_documentation[] =
 "I18n Messages";
 
-#if PY_MAJOR_VERSION >= 3
-  static struct PyModuleDef moduledef = {
+static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
     _zope_i18nmessageid_message_module_name,/* m_name */
     _zope_i18nmessageid_message_module_documentation,/* m_doc */
@@ -294,44 +283,36 @@ static char _zope_i18nmessageid_message_module_documentation[] =
     NULL,/* m_traverse */
     NULL,/* m_clear */
     NULL,/* m_free */
-  };
-#endif
+};
 
-#ifndef PyMODINIT_FUNC  /* declarations for DLL import/export */
-  #define PyMODINIT_FUNC void
-#endif
 
-PyMODINIT_FUNC
-#if PY_MAJOR_VERSION >= 3
- PyInit__zope_i18nmessageid_message(void)
-#else
- init_zope_i18nmessageid_message(void)
-#endif
+static PyObject*
+init(void)
 {
   PyObject *m;
   /* Initialize types: */
   MessageType.tp_base = &PyUnicode_Type;
-  if (PyType_Ready(&MessageType) < 0)
-    return MOD_ERROR_VAL;
+  if (PyType_Ready(&MessageType) < 0) {
+    return NULL;
+  }
 
   /* Create the module and add the functions */
-#if PY_MAJOR_VERSION >= 3
   m = PyModule_Create(&moduledef);
-#else
-  m = Py_InitModule3(_zope_i18nmessageid_message_module_name,
-                     _zope_i18nmessageid_message_methods,
-                     _zope_i18nmessageid_message_module_documentation);
-#endif
 
-  if (m == NULL)
-    return MOD_ERROR_VAL;
+  if (m == NULL) {
+    return NULL;
+  }
 
   /* Add types: */
-  if (PyModule_AddObject(m, "Message", (PyObject *)&MessageType) < 0)
-    return MOD_ERROR_VAL;
+  if (PyModule_AddObject(m, "Message", (PyObject *)&MessageType) < 0) {
+    return NULL;
+  }
 
-#if PY_MAJOR_VERSION >= 3
   return m;
-#endif
+}
 
+PyMODINIT_FUNC
+PyInit__zope_i18nmessageid_message(void)
+{
+    return init();
 }

--- a/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
+++ b/src/zope/i18nmessageid/_zope_i18nmessageid_message.c
@@ -337,15 +337,17 @@ typedef struct {
  */
 static int is_message(PyTypeObject* type, PyObject* obj)
 {
+    PyTypeObject* message_type;
 #if USE_STATIC_TYPES
-    return PyObject_TypeCheck(obj, &MessageType);
+    message_type = &MessageType;
 #else
     _zim_module_state* rec = (_zim_module_state*)PyType_GetModuleState(type);
     /* PT_GMS will already have set the exception */
     if (rec == NULL) { return 0; }
 
-    return PyObject_TypeCheck(obj, rec->message_type);
+    message_type = rec->message_type;
 #endif
+    return PyObject_TypeCheck(obj, message_type);
 }
 
 static _zim_module_state*


### PR DESCRIPTION
Includes making the `Message` type heap-allocated for Python >= 3.9.

I mean to port the mechanism developed here (allowing multi-phase for all Python verisons) to the `zope.interface` branch in https://github.com/zopefoundation/zope.interface/pull/301, which should make it suitable for merging.