### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-7.1 (unreleased)
+8.0 (unreleased)
 ================
 
 - Add preliminary support for Python 3.14 as of 3.14a4.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 8.0 (unreleased)
 ================
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Add preliminary support for Python 3.14 as of 3.14a4.
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ class optional_build_ext(build_ext):
 
 setup(
     name='zope.i18nmessageid',
-    version='7.1.dev0',
+    version='8.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description='Message Identifiers for internationalization',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ import platform
 import sys
 
 from setuptools import Extension
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -60,7 +59,7 @@ if not is_pypy and not is_jython:
 
 
 tests_require = [
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'coverage',
 ]
 
@@ -133,9 +132,10 @@ setup(
     ],
     license='ZPL-2.1',
     url='https://github.com/zopefoundation/zope.i18nmessageid',
-    packages=find_packages('src'),
+    # we need the following two parameters because we compile C code,
+    # otherwise only the shared library is installed:
     package_dir={'': 'src'},
-    namespace_packages=['zope'],
+    packages=['zope.i18nmessageid'],
     install_requires=['setuptools'],
     python_requires='>=3.9',
     include_package_data=True,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
